### PR TITLE
Automate semester switching

### DIFF
--- a/bot/auto_pin.py
+++ b/bot/auto_pin.py
@@ -33,7 +33,13 @@ class AutoPin(commands.Cog):
             yes_count += reaction.count
 
         # if error occurs, it should be handled by cog_command_error
-        await message.pin()
+        if yes_count >= self.pin_threshold:
+            try:
+                await message.pin()
+            except discord.HTTPException:
+                raise Exception(f"Pin limit for a channel {message.channel} has been reached."
+                                f"User trying to pin: {user.jump_url}"
+                                f"Message: {message.jump_url}")
 
     @commands.Cog.listener()
     async def on_reaction_remove(self, reaction: discord.Reaction,

--- a/bot/auto_pin.py
+++ b/bot/auto_pin.py
@@ -5,6 +5,8 @@ from discord.ext import commands
 
 from typing import Union
 
+from error_handling import send_error_message_to_user
+
 
 class AutoPin(commands.Cog):
     def __init__(self, bot: discord.Bot) -> None:
@@ -30,13 +32,8 @@ class AutoPin(commands.Cog):
                          if x.emoji == self.pin_emoji]:
             yes_count += reaction.count
 
-        if yes_count >= self.pin_threshold:
-            try:
-                await message.pin()
-            except discord.HTTPException:
-                print('Pin limit for a channel has been reached')
-            finally:
-                pass
+        # if error occurs, it should be handled by cog_command_error
+        await message.pin()
 
     @commands.Cog.listener()
     async def on_reaction_remove(self, reaction: discord.Reaction,
@@ -56,10 +53,11 @@ class AutoPin(commands.Cog):
             yes_count += reaction.count
 
         if yes_count <= self.unpin_threshold:
-            try:
-                await message.unpin()
-            finally:
-                pass
+            await message.unpin()
+
+
+    async def cog_command_error(self, ctx: discord.ApplicationContext, error: commands.CommandError) -> None:
+        await send_error_message_to_user(ctx, error)
 
 
 def setup(bot: discord.Bot) -> None:

--- a/bot/auto_pin.py
+++ b/bot/auto_pin.py
@@ -37,9 +37,9 @@ class AutoPin(commands.Cog):
             try:
                 await message.pin()
             except discord.HTTPException:
-                raise Exception(f"Pin limit for a channel {message.channel} has been reached."
-                                f"User trying to pin: {user.jump_url}"
-                                f"Message: {message.jump_url}")
+                raise Exception(f"Pin limit pro channel {message.channel} byl dosažen."
+                                f"Uživatel, který chtěl pinnout: {user.jump_url}"
+                                f"Zpráva k pinnutí: {message.jump_url}")
 
     @commands.Cog.listener()
     async def on_reaction_remove(self, reaction: discord.Reaction,

--- a/bot/auto_voice.py
+++ b/bot/auto_voice.py
@@ -97,12 +97,6 @@ class AutoVoice(commands.Cog):
 
         await ctx.respond("Invalid storage!")
 
-    # handle command errors
-    @set_auto_voice.error
-    async def admin_command_error(self, ctx: discord.ApplicationContext, error: commands.CommandError) -> None:
-        if isinstance(error, commands.MissingPermissions):
-            await ctx.respond("You do not have the required permissions to run this command.")
-
     async def cog_command_error(self, ctx: discord.ApplicationContext, error: commands.CommandError) -> None:
         await send_error_message_to_user(ctx, error)
 

--- a/bot/auto_voice.py
+++ b/bot/auto_voice.py
@@ -76,26 +76,25 @@ class AutoVoice(commands.Cog):
     # set the automatic voice master ID to the one specified by the user
     @commands.slash_command(name="set-auto-voice-channel")
     @commands.has_permissions(administrator=True)
-    async def set_auto_voice(self, ctx: discord.ApplicationContext, auto_channel_id: str, storage: str) -> None:
-        try:
-            auto_channel_id = int(auto_channel_id)
-        except ValueError:
-            await ctx.respond("Invalid value for auto_channel_id")
-            return
+    async def set_auto_voice(self,
+                             ctx: discord.ApplicationContext,
+                             auto_channel_id: int,
+                             storage: discord.Option(
+                                 str,
+                                 description="Lokálně do proměnné či DB (Databáze preferováno)",
+                                 choices=["local", "db"]
+                             )) -> None:
 
         # check if the id should be stored locally
         if storage == "local":
             self.channel_id = auto_channel_id
-            await ctx.respond("Automatic voice channel set locally!")
+            await ctx.respond("Hodnota nastavena do lokální proměnné platné v rámci runtime.", ephemeral=True)
             return
-
-        if storage == "db":
+        elif storage == "db":
             db.voice_channel_id = auto_channel_id
             self.channel_id = auto_channel_id
-            await ctx.respond("Automatic voice channel set in the database!")
+            await ctx.respond("Hodnota nastavena do databáze.", ephemeral=True)
             return
-
-        await ctx.respond("Invalid storage!")
 
     async def cog_command_error(self, ctx: discord.ApplicationContext, error: commands.CommandError) -> None:
         await send_error_message_to_user(ctx, error)

--- a/bot/auto_voice.py
+++ b/bot/auto_voice.py
@@ -74,7 +74,7 @@ class AutoVoice(commands.Cog):
             await before.channel.delete()
 
     # set the automatic voice master ID to the one specified by the user
-    @commands.slash_command(name="setautovoicechannel")
+    @commands.slash_command(name="set-auto-voice-channel")
     @commands.has_permissions(administrator=True)
     async def set_auto_voice(self, ctx: discord.ApplicationContext, auto_channel_id: str, storage: str) -> None:
         try:

--- a/bot/countdown.py
+++ b/bot/countdown.py
@@ -56,7 +56,7 @@ class CountDown(commands.Cog):
             f"***Tvá smrt v podobě zkoušky z APPS přichází za {hours} {hours_str} {minutes} {minutes_str} a {seconds} {seconds_str}.*** {emoji}\n"
             f"*||Zlé hlasy říkají, že úspěšnost je 50%. :skull:||*")
 
-    @commands.slash_command(name='start_countdown')
+    @commands.slash_command(name='start-countdown')
     async def start_countdown(self, ctx: discord.ApplicationContext):
         if self.started:
             await ctx.respond("Odpočet už běží.", ephemeral=True)

--- a/bot/counter.py
+++ b/bot/counter.py
@@ -74,7 +74,7 @@ async def add_emote(message: discord.Message, emote_name: str) -> None:
         emoji = discord.utils.get(guild.emojis, name=emote_name)
         await message.add_reaction(emoji)
     except discord.errors.InvalidArgument as e:
-        print(f"You can ignore this warning, it comes from typing Tobiáš or Poli with missing emote.\n{e}")
+        print(f"Neexistuje emote s daným jménem.\n{e}")
 
 
 class Counter(commands.Cog):

--- a/bot/database_communication.py
+++ b/bot/database_communication.py
@@ -6,15 +6,42 @@ from error_handling import send_error_message_to_user
 from start import db
 
 
-class DatabaseCommunication:
+class DatabaseCommunication(commands.Cog):
     def __init__(self, bot: discord.bot) -> None:
         self.bot = bot
 
     @commands.slash_command(name='insert-or-update-value',
                             description='Tento příkaz vloží či upraví proměnnou v DB.')
     @commands.has_permissions(administrator=True)
-    async def insert_or_update_value(self, name: str, value: discord.Option()) -> None:
-        ...
+    async def insert_or_update_value(self,
+                                     ctx: discord.ApplicationContext,
+                                     name: str,
+                                     value: str,
+                                     value_type: discord.Option(
+                                         str,
+                                         description="Jakého typu je proměnná?",
+                                         choices=["int", "float", "str"]
+                                     )) -> None:
+
+        try:
+            # Type checking
+            if value_type == "str":
+                ...
+            elif value_type == "int":
+                value = int(value)
+            elif value_type == "float":
+                value = float(value)
+            else:
+                raise ValueError()
+        except ValueError:
+            # If something is wrong with value and value_type
+            await ctx.respond(
+                f"Nesprávná hodnota či nelze převést zadanou hodnotu {value} na daný datový typ {value_type}.", ephemeral=True)
+        else:
+            # Insert or update in MongoDB
+            await db.insert_or_update_into_variables(name, value)
+
+        await ctx.respond("Hodnota vložena/změněna úspěšně.", ephemeral=True)
 
     async def cog_command_error(self, ctx: discord.ApplicationContext, error: commands.CommandError) -> None:
         await send_error_message_to_user(ctx, error)

--- a/bot/database_communication.py
+++ b/bot/database_communication.py
@@ -36,12 +36,14 @@ class DatabaseCommunication(commands.Cog):
         except ValueError:
             # If something is wrong with value and value_type
             await ctx.respond(
-                f"Nesprávná hodnota či nelze převést zadanou hodnotu {value} na daný datový typ {value_type}.", ephemeral=True)
+                f"Nesprávná hodnota či nelze převést zadanou hodnotu {value} na daný datový typ {value_type}.",
+                ephemeral=True)
         else:
             # Insert or update in MongoDB
             await db.insert_or_update_into_variables(name, value)
 
-        await ctx.respond("Hodnota vložena/změněna úspěšně.", ephemeral=True)
+        await ctx.respond(f"Hodnota s názvnem {name} typu {value_type} a hodnotou {value} vložena/změněna úspěšně.",
+                          ephemeral=True)
 
     async def cog_command_error(self, ctx: discord.ApplicationContext, error: commands.CommandError) -> None:
         await send_error_message_to_user(ctx, error)

--- a/bot/database_communication.py
+++ b/bot/database_communication.py
@@ -1,0 +1,24 @@
+"""This module is used to change and insert variables in DB via slash commands on discord."""
+import discord
+from discord.ext import commands
+
+from error_handling import send_error_message_to_user
+from start import db
+
+
+class DatabaseCommunication:
+    def __init__(self, bot: discord.bot) -> None:
+        self.bot = bot
+
+    @commands.slash_command(name='insert-or-update-value',
+                            description='Tento příkaz vloží či upraví proměnnou v DB.')
+    @commands.has_permissions(administrator=True)
+    async def insert_or_update_value(self, name: str, value: discord.Option()) -> None:
+        ...
+
+    async def cog_command_error(self, ctx: discord.ApplicationContext, error: commands.CommandError) -> None:
+        await send_error_message_to_user(ctx, error)
+
+
+def setup(bot: discord.Bot) -> None:
+    bot.add_cog(DatabaseCommunication(bot))

--- a/bot/help.py
+++ b/bot/help.py
@@ -1,0 +1,23 @@
+"""This module is for help commands bot will provide."""
+
+import discord
+from discord.ext import commands
+
+from error_handling import send_error_message_to_user
+
+
+class Help(commands.Cog):
+    def __init__(self, bot: discord.Bot):
+        self.bot = bot
+
+    @commands.slash_command(name='github',
+                            description='Tento příkaz ti pošle náš link na github!')
+    async def github(self, ctx: discord.ApplicationContext) -> None:
+        await ctx.respond("https://github.com/SirValecekLuis/DiscordBot", ephemeral=True)
+
+    async def cog_command_error(self, ctx: discord.ApplicationContext, error: commands.CommandError) -> None:
+        await send_error_message_to_user(ctx, error)
+
+
+def setup(bot: discord.Bot) -> None:
+    bot.add_cog(Help(bot))

--- a/bot/leaderboard.py
+++ b/bot/leaderboard.py
@@ -36,6 +36,7 @@ class CounterLeaderboard(commands.Cog):
                                       ) -> None:
         """Sends a list of people with the highest sum of counters to the user
 
+        :param ctx: Context of slash command
         :param limit_str: optional limit on how many people will be displayed
         :return: None
         """
@@ -56,10 +57,9 @@ class CounterLeaderboard(commands.Cog):
                     limit = tmp_limit
             except ValueError:
                 # notify user of failure to parse their limit to int
-                await ctx.respond("Couldn't parse limit into `int`. " +
-                                  "Likely a wrong input format " +
-                                  "(expected a number)",
-                                  ephemeral=True)
+                await ctx.respond(
+                    "Zadaný limit nemohl být převeden na číslo. Pravděpodobně špatný formát, je očekáváno celé číslo.",
+                    ephemeral=True)
                 return
 
         # create a response string
@@ -67,17 +67,15 @@ class CounterLeaderboard(commands.Cog):
 
         # build the response by adding leaderboard entries to it
         try:
-            for index, (key, value) in zip(range(1, limit+1),
+            for index, (key, value) in zip(range(1, limit + 1),
                                            leaderboard.items()):
                 response += f'{index}. <@{key}>: {value}\n'
 
             # send the response to the user
             await ctx.respond(response, ephemeral=True)
         except AttributeError:
-            # notify user of a error in displaying the leaderboard
-            await ctx.respond("The leaderboard couldn't be displayed " +
-                              "(most likely couldn't be quarried " +
-                              "from database)",
+            # notify user of an error in displaying the leaderboard
+            await ctx.respond("Leadboard nemohl být načten, pravděpodobně kvůli chybě ze strany databáze.",
                               ephemeral=True)
             return
 

--- a/bot/semester_switching.py
+++ b/bot/semester_switching.py
@@ -1,0 +1,43 @@
+"""This module is for semestr switching, wow."""
+import discord
+from discord.ext import commands
+from discord import Option
+
+from error_handling import send_error_message_to_user
+
+
+class SemesterSwitching(commands.Cog):
+    def __init__(self, bot: discord.Bot) -> None:
+        self.bot = bot
+
+    def switch_categories(self, category: discord.CategoryChannel):
+        print(category.name)
+
+    @commands.slash_command(name='switch-semester',
+                            description='Tento příkaz přehází semestry do správných kategorii pro nový semestr.')
+    @commands.has_permissions(administrator=True)
+    async def switch_semester(
+            self,
+            ctx: discord.ApplicationContext,
+            semester_to_switch: Option(
+                str,
+                description="Zadejte semestr, na který chcete přepnout (bude další) (W (winter) - S (summer))",
+                choices=["W", "S"],
+                required=True
+            )
+    ) -> None:
+        # TODO: test what happens if someone calls this without ADMIN perms
+
+        for category in ctx.guild.categories:
+            category_name = category.name.split()
+            if len(category_name[0]) == 2 and category_name[1] == "semestr":
+                self.switch_categories(category)
+
+        await ctx.respond("Channels switched!", ephemeral=True)
+
+    async def cog_command_error(self, ctx: discord.ApplicationContext, error: commands.CommandError) -> None:
+        await send_error_message_to_user(ctx, error)
+
+
+def setup(bot: discord.Bot) -> None:
+    bot.add_cog(SemesterSwitching(bot))

--- a/bot/semester_switching.py
+++ b/bot/semester_switching.py
@@ -83,8 +83,9 @@ class SemesterSwitching(commands.Cog):
     async def switch_semester(self, ctx: discord.ApplicationContext) -> None:
         """
         PREREQUISITES
-        channel name is in this way: "x. semestr" or "x. semestr - archiv" and only 0-9 is supported right now.
-        discord roles will follow the same pattern as "EMOJI NUMBER NAME" such as "1️⃣ Prvák" and will not be changed.
+        Channel name is in this way: "x. semestr" or "x. semestr - archiv" and only 0-9 is supported right now.
+        Discord role ID will be inserted in DB with name x_year_role_id with value of ID (int) of given role.
+        (Can be obtained via discord when activating developer mode and then right-clicking on role)
         """
         # TODO: add some level of stupid proofing (maybe some kind of acceptance from others or something like that)
 
@@ -110,12 +111,12 @@ class SemesterSwitching(commands.Cog):
             text = " | ".join([category.name for category in visited_categories])
             if len(visited_categories) == 0:
                 text = "NO CHANNELS"
-            raise Exception("semester_switching failed. 15m API response was not enough. In this case, unfortunately,"
-                            "we have no idea what was executed and what was not. Therefore there is a list of"
-                            "categories that have been/could have been changed with error attached." + text + str(e))
+            raise Exception("API neodpovědělo do 15 minut. Channely, které mohly být ovlivněny, jsou vypsány společně s"
+                            "chybovou hláškou, která stála za pád tohoto commandu." + text + str(e))
         except Exception as e:
             text = " | ".join([category.name for category in visited_categories])
-            raise Exception("Something failed. processed categories attached + error" + text + str(e))
+            raise Exception(
+                "Něco selhalo. Teoreticky ovlivněné kategorie + chybová hláška bude vypsána." + text + str(e))
 
     async def cog_command_error(self, ctx: discord.ApplicationContext, error: commands.CommandError) -> None:
         await send_error_message_to_user(ctx, error)

--- a/bot/semester_switching.py
+++ b/bot/semester_switching.py
@@ -1,39 +1,65 @@
 """This module is for semestr switching, wow."""
 import discord
 from discord.ext import commands
-from discord import Option
+import math
 
 from error_handling import send_error_message_to_user
+
+ROLES = {1: "1️⃣ Prvák", 2: "2️⃣ Druhák", 3: "3️⃣ Třeťák", 4: "4️⃣ Čtvrťák", 5: "5️⃣ Páťák"}
 
 
 class SemesterSwitching(commands.Cog):
     def __init__(self, bot: discord.Bot) -> None:
         self.bot = bot
 
-    def switch_categories(self, category: discord.CategoryChannel):
-        print(category.name)
-
     @commands.slash_command(name='switch-semester',
                             description='Tento příkaz přehází semestry do správných kategorii pro nový semestr.')
     @commands.has_permissions(administrator=True)
-    async def switch_semester(
-            self,
-            ctx: discord.ApplicationContext,
-            semester_to_switch: Option(
-                str,
-                description="Zadejte semestr, na který chcete přepnout (bude další) (W (winter) - S (summer))",
-                choices=["W", "S"],
-                required=True
-            )
-    ) -> None:
+    async def switch_semester(self, ctx: discord.ApplicationContext) -> None:
+        """
+        PREREQUISITES
+        channel name is in this way: "x. semestr" or "x. semestr - archiv"
+        discord roles will follow the same pattern as "EMOJI NUMBER NAME" such as "1️⃣ Prvák" and will not be changed
+        """
         # TODO: test what happens if someone calls this without ADMIN perms
+        try:
+            await ctx.defer(ephemeral=True)  # Discord API takes way too long to respond
 
-        for category in ctx.guild.categories:
-            category_name = category.name.split()
-            if len(category_name[0]) == 2 and category_name[1] == "semestr":
-                self.switch_categories(category)
+            for category in ctx.guild.categories:
+                category_name = category.name.split()
+                if len(category_name[0]) == 2 and category_name[1] == "semestr" and len(category_name) == 2:
+                    # Semester is active and should be put as archive
 
-        await ctx.respond("Channels switched!", ephemeral=True)
+                    # Removes role (prvák, druhák...)
+                    new_overwrites = category.overwrites
+                    for role_name, overwrite in category.overwrites.items():
+                        year = math.ceil(int(category_name[0][0]) / 2)  # [1]. semestr = 1/2 = ceil(0.5) = 1. year
+                        if role_name.name == ROLES[year]:
+                            role_to_remove = discord.utils.get(category.guild.roles, name=ROLES[year])
+                            new_overwrites = {role: overwrite for role, overwrite in category.overwrites.items() if
+                                              role != role_to_remove}
+
+                    # Name of channel
+                    name = category.name + " - archiv"
+                    print("archived")
+                    print(name)
+
+                    # Final edit of category
+                    await category.edit(name=name, overwrites=new_overwrites)
+                elif len(category_name[0]) == 2 and category_name[1] == "semestr" and len(category_name) > 2:
+                    # Semester is archived and should be put as active
+
+                    # Name of channel
+                    name = category_name[0] + " " + category_name[1]
+                    print("active")
+                    print(name)
+
+                    # Final edit of category
+                    await category.edit(name=name)
+
+            await ctx.followup.send("Channels switched!", ephemeral=True)
+        except discord.HTTPException as e:
+            raise Exception("semester_switching failed. 15m API response was not enough." + e)
 
     async def cog_command_error(self, ctx: discord.ApplicationContext, error: commands.CommandError) -> None:
         await send_error_message_to_user(ctx, error)

--- a/bot/semester_switching.py
+++ b/bot/semester_switching.py
@@ -13,7 +13,7 @@ class SemesterSwitching(commands.Cog):
         self.bot = bot
 
     async def switch_to_archived(self, category: discord.CategoryChannel, category_name: list,
-                                 visited_categories: list):
+                                 visited_categories: list) -> None:
         """
         Adds - archive to a category name
         Removes role (prvák, druhák...)
@@ -46,7 +46,8 @@ class SemesterSwitching(commands.Cog):
         for channel in category.channels:
             await channel.edit(sync_permissions=True)
 
-    async def switch_to_active(self, category: discord.CategoryChannel, category_name: list, visited_categories: list):
+    async def switch_to_active(self, category: discord.CategoryChannel, category_name: list,
+                               visited_categories: list) -> None:
         """
         Removes - archive from name
         Adds role (prvák, druhák...) and enables View Channel for the role
@@ -111,10 +112,10 @@ class SemesterSwitching(commands.Cog):
                 text = "NO CHANNELS"
             raise Exception("semester_switching failed. 15m API response was not enough. In this case, unfortunately,"
                             "we have no idea what was executed and what was not. Therefore there is a list of"
-                            "categories that have been/could have been changed with error attached." + text + e)
+                            "categories that have been/could have been changed with error attached." + text + str(e))
         except Exception as e:
             text = " | ".join([category.name for category in visited_categories])
-            raise Exception("Something failed. processed categories attached + error" + text + e)
+            raise Exception("Something failed. processed categories attached + error" + text + str(e))
 
     async def cog_command_error(self, ctx: discord.ApplicationContext, error: commands.CommandError) -> None:
         await send_error_message_to_user(ctx, error)

--- a/bot/semester_switching.py
+++ b/bot/semester_switching.py
@@ -1,4 +1,4 @@
-"""This module is for semestr switching, wow."""
+"""This module is for semester switching, wow."""
 import discord
 from discord.ext import commands
 import math
@@ -18,19 +18,30 @@ class SemesterSwitching(commands.Cog):
     async def switch_semester(self, ctx: discord.ApplicationContext) -> None:
         """
         PREREQUISITES
-        channel name is in this way: "x. semestr" or "x. semestr - archiv"
-        discord roles will follow the same pattern as "EMOJI NUMBER NAME" such as "1️⃣ Prvák" and will not be changed
+        channel name is in this way: "x. semestr" or "x. semestr - archiv" and only 0-9 is supported right now.
+        discord roles will follow the same pattern as "EMOJI NUMBER NAME" such as "1️⃣ Prvák" and will not be changed.
         """
         # TODO: test what happens if someone calls this without ADMIN perms
+        # TODO: add some level of stupid proofing (maybe some kind of acceptance from others or something like that)
         try:
+            await ctx.send("Please, bear in mind this command may take several minutes due to discord API calls.",
+                           delete_after=True)
             await ctx.defer(ephemeral=True)  # Discord API takes way too long to respond
 
+            # This is just for error purposes
+            visited_categories = []
             for category in ctx.guild.categories:
+                print(category)
                 category_name = category.name.split()
                 if len(category_name[0]) == 2 and category_name[1] == "semestr" and len(category_name) == 2:
-                    # Semester is active and should be put as archive
+                    # Semester is active and should be put as archived
 
-                    # Removes role (prvák, druhák...)
+                    """
+                    Adds - archive to a category name
+                    Removes role (prvák, druhák...)
+                    Disallows public/private threads, send messages in them and sending messages overall for everyone
+                    Resets View Channel for everyone to its default state
+                    """
                     new_overwrites = category.overwrites
                     for role_name, overwrite in category.overwrites.items():
                         year = math.ceil(int(category_name[0][0]) / 2)  # [1]. semestr = 1/2 = ceil(0.5) = 1. year
@@ -38,6 +49,13 @@ class SemesterSwitching(commands.Cog):
                             role_to_remove = discord.utils.get(category.guild.roles, name=ROLES[year])
                             new_overwrites = {role: overwrite for role, overwrite in category.overwrites.items() if
                                               role != role_to_remove}
+                    new_overwrites[category.guild.default_role] = discord.PermissionOverwrite(
+                        create_public_threads=False,
+                        create_private_threads=False,
+                        send_messages_in_threads=False,
+                        send_messages=False,
+                        view_channel=None
+                    )
 
                     # Name of channel
                     name = category.name + " - archiv"
@@ -45,9 +63,28 @@ class SemesterSwitching(commands.Cog):
                     print(name)
 
                     # Final edit of category
+                    visited_categories.append(category)
                     await category.edit(name=name, overwrites=new_overwrites)
-                elif len(category_name[0]) == 2 and category_name[1] == "semestr" and len(category_name) > 2:
+                elif len(category_name[0]) == 2 and category_name[1] == "semestr" and category_name[3] == "archiv":
                     # Semester is archived and should be put as active
+
+                    """
+                    Removes - archive from name
+                    Adds role (prvák, druhák...) and enables View Channel for the role
+                    Disallows view channel for everyone
+                    Allows Send Messages, Send Messages in Threads and Create Private/Public threads for everyone
+                    """
+                    new_overwrites = category.overwrites
+                    year = math.ceil(int(category_name[0][0]) / 2)  # [1]. semestr = 1/2 = ceil(0.5) = 1. year
+                    role_to_add = discord.utils.get(category.guild.roles, name=ROLES[year])
+                    new_overwrites[role_to_add] = discord.PermissionOverwrite(view_channel=True)
+                    new_overwrites[category.guild.default_role] = discord.PermissionOverwrite(
+                        view_channel=False,
+                        create_public_threads=True,
+                        create_private_threads=True,
+                        send_messages_in_threads=True,
+                        send_messages=True
+                    )
 
                     # Name of channel
                     name = category_name[0] + " " + category_name[1]
@@ -55,11 +92,15 @@ class SemesterSwitching(commands.Cog):
                     print(name)
 
                     # Final edit of category
-                    await category.edit(name=name)
+                    visited_categories.append(category)
+                    await category.edit(name=name, overwrites=new_overwrites)
 
             await ctx.followup.send("Channels switched!", ephemeral=True)
         except discord.HTTPException as e:
-            raise Exception("semester_switching failed. 15m API response was not enough." + e)
+            text = " | ".join([category.name for category in visited_categories])
+            raise Exception("semester_switching failed. 15m API response was not enough. In this case, unfortunately,"
+                            "we have no idea what was executed and what was not. Therefore there is a list of"
+                            "categories that have been/could have been changed with error attached." + text + e)
 
     async def cog_command_error(self, ctx: discord.ApplicationContext, error: commands.CommandError) -> None:
         await send_error_message_to_user(ctx, error)

--- a/bot/semester_switching.py
+++ b/bot/semester_switching.py
@@ -12,6 +12,70 @@ class SemesterSwitching(commands.Cog):
     def __init__(self, bot: discord.Bot) -> None:
         self.bot = bot
 
+    async def switch_to_archived(self, category: discord.CategoryChannel, category_name: list,
+                                 visited_categories: list):
+        """
+        Adds - archive to a category name
+        Removes role (prvák, druhák...)
+        Disallows public/private threads, send messages in them and sending messages overall for everyone
+        Resets View Channel for everyone to its default state
+        """
+        new_overwrites = category.overwrites
+        for role_name, overwrite in category.overwrites.items():
+            year = math.ceil(int(category_name[0][0]) / 2)  # [1]. semestr = 1/2 = ceil(0.5) = 1. year
+            if role_name.name == ROLES[year]:
+                role_to_remove = discord.utils.get(category.guild.roles, name=ROLES[year])
+                new_overwrites = {role: overwrite for role, overwrite in category.overwrites.items() if
+                                  role != role_to_remove}
+        new_overwrites[category.guild.default_role] = discord.PermissionOverwrite(
+            create_public_threads=False,
+            create_private_threads=False,
+            send_messages_in_threads=False,
+            send_messages=False,
+            view_channel=None
+        )
+
+        # Name of channel
+        name = category.name + " - archiv"
+
+        # Final edit of category
+        visited_categories.append(category)
+        await category.edit(name=name, overwrites=new_overwrites)
+
+        # sync perms after editing category
+        for channel in category.channels:
+            await channel.edit(sync_permissions=True)
+
+    async def switch_to_active(self, category: discord.CategoryChannel, category_name: list, visited_categories: list):
+        """
+        Removes - archive from name
+        Adds role (prvák, druhák...) and enables View Channel for the role
+        Disallows view channel for everyone
+        Allows Send Messages, Send Messages in Threads and Create Private/Public threads for everyone
+        """
+        new_overwrites = category.overwrites
+        year = math.ceil(int(category_name[0][0]) / 2)  # [1]. semestr = 1/2 = ceil(0.5) = 1. year
+        role_to_add = discord.utils.get(category.guild.roles, name=ROLES[year])
+        new_overwrites[role_to_add] = discord.PermissionOverwrite(view_channel=True)
+        new_overwrites[category.guild.default_role] = discord.PermissionOverwrite(
+            view_channel=False,
+            create_public_threads=True,
+            create_private_threads=True,
+            send_messages_in_threads=True,
+            send_messages=True
+        )
+
+        # Name of channel
+        name = category_name[0] + " " + category_name[1]
+
+        # Final edit of category
+        visited_categories.append(category)
+        await category.edit(name=name, overwrites=new_overwrites)
+
+        # sync perms after editing category
+        for channel in category.channels:
+            await channel.edit(sync_permissions=True)
+
     @commands.slash_command(name='switch-semester',
                             description='Tento příkaz přehází semestry do správných kategorii pro nový semestr.')
     @commands.has_permissions(administrator=True)
@@ -21,86 +85,36 @@ class SemesterSwitching(commands.Cog):
         channel name is in this way: "x. semestr" or "x. semestr - archiv" and only 0-9 is supported right now.
         discord roles will follow the same pattern as "EMOJI NUMBER NAME" such as "1️⃣ Prvák" and will not be changed.
         """
-        # TODO: test what happens if someone calls this without ADMIN perms
         # TODO: add some level of stupid proofing (maybe some kind of acceptance from others or something like that)
+
+        # This is just for error purposes
+        visited_categories = []
         try:
-            await ctx.send("Please, bear in mind this command may take several minutes due to discord API calls.",
-                           delete_after=True)
             await ctx.defer(ephemeral=True)  # Discord API takes way too long to respond
+            await ctx.followup.send("Tento příkaz může trvat několik minut kvůli API callům. Zpracovávám...")
 
-            # This is just for error purposes
-            visited_categories = []
             for category in ctx.guild.categories:
-                print(category)
                 category_name = category.name.split()
+
+                # Semester is active and should be put as archived
                 if len(category_name[0]) == 2 and category_name[1] == "semestr" and len(category_name) == 2:
-                    # Semester is active and should be put as archived
+                    await self.switch_to_archived(category, category_name, visited_categories)
 
-                    """
-                    Adds - archive to a category name
-                    Removes role (prvák, druhák...)
-                    Disallows public/private threads, send messages in them and sending messages overall for everyone
-                    Resets View Channel for everyone to its default state
-                    """
-                    new_overwrites = category.overwrites
-                    for role_name, overwrite in category.overwrites.items():
-                        year = math.ceil(int(category_name[0][0]) / 2)  # [1]. semestr = 1/2 = ceil(0.5) = 1. year
-                        if role_name.name == ROLES[year]:
-                            role_to_remove = discord.utils.get(category.guild.roles, name=ROLES[year])
-                            new_overwrites = {role: overwrite for role, overwrite in category.overwrites.items() if
-                                              role != role_to_remove}
-                    new_overwrites[category.guild.default_role] = discord.PermissionOverwrite(
-                        create_public_threads=False,
-                        create_private_threads=False,
-                        send_messages_in_threads=False,
-                        send_messages=False,
-                        view_channel=None
-                    )
-
-                    # Name of channel
-                    name = category.name + " - archiv"
-                    print("archived")
-                    print(name)
-
-                    # Final edit of category
-                    visited_categories.append(category)
-                    await category.edit(name=name, overwrites=new_overwrites)
+                # Semester is archived and should be put as active
                 elif len(category_name[0]) == 2 and category_name[1] == "semestr" and category_name[3] == "archiv":
-                    # Semester is archived and should be put as active
+                    await self.switch_to_active(category, category_name, visited_categories)
 
-                    """
-                    Removes - archive from name
-                    Adds role (prvák, druhák...) and enables View Channel for the role
-                    Disallows view channel for everyone
-                    Allows Send Messages, Send Messages in Threads and Create Private/Public threads for everyone
-                    """
-                    new_overwrites = category.overwrites
-                    year = math.ceil(int(category_name[0][0]) / 2)  # [1]. semestr = 1/2 = ceil(0.5) = 1. year
-                    role_to_add = discord.utils.get(category.guild.roles, name=ROLES[year])
-                    new_overwrites[role_to_add] = discord.PermissionOverwrite(view_channel=True)
-                    new_overwrites[category.guild.default_role] = discord.PermissionOverwrite(
-                        view_channel=False,
-                        create_public_threads=True,
-                        create_private_threads=True,
-                        send_messages_in_threads=True,
-                        send_messages=True
-                    )
-
-                    # Name of channel
-                    name = category_name[0] + " " + category_name[1]
-                    print("active")
-                    print(name)
-
-                    # Final edit of category
-                    visited_categories.append(category)
-                    await category.edit(name=name, overwrites=new_overwrites)
-
-            await ctx.followup.send("Channels switched!", ephemeral=True)
+            await ctx.followup.send("Prohození semestrů bylo dokončeno!", ephemeral=True)
         except discord.HTTPException as e:
             text = " | ".join([category.name for category in visited_categories])
+            if len(visited_categories) == 0:
+                text = "NO CHANNELS"
             raise Exception("semester_switching failed. 15m API response was not enough. In this case, unfortunately,"
                             "we have no idea what was executed and what was not. Therefore there is a list of"
                             "categories that have been/could have been changed with error attached." + text + e)
+        except Exception as e:
+            text = " | ".join([category.name for category in visited_categories])
+            raise Exception("Something failed. processed categories attached + error" + text + e)
 
     async def cog_command_error(self, ctx: discord.ApplicationContext, error: commands.CommandError) -> None:
         await send_error_message_to_user(ctx, error)

--- a/database.py
+++ b/database.py
@@ -58,6 +58,16 @@ class Database:
         """
         self.__variables.update_one({}, {"$set": {name: value}})
 
+    async def get_variable_from_variables(self, name: str) -> Optional[object]:
+        """
+        Function will try to obtain value from database of given name. None when doesn't exist.
+        :param name: Name of variable in DB
+        :return: Variable value or None
+        """
+        try:
+            return self.__variables.find_one()[name]
+        except KeyError:
+            return None
 
 class InvalidVariablesCount(Exception):
     def __init__(self, err_message):

--- a/database.py
+++ b/database.py
@@ -2,7 +2,6 @@
 import pymongo.collection
 from pymongo import MongoClient
 from typing import Optional
-
 DB_NAME = "DiscordBot"
 
 
@@ -49,6 +48,15 @@ class Database:
         """
 
         return self.__counter.find_one({"id": user_id})
+
+    async def insert_or_update_into_variables(self, name: str, value: object) -> None:
+        """
+        Function will insert variable with name and value in variables collection in MongoDB.
+        :param name: string for variable name
+        :param value: value which can be of many types.
+        :return: None
+        """
+        self.__variables.update_one({}, {"$set": {name: value}})
 
 
 class InvalidVariablesCount(Exception):

--- a/database.py
+++ b/database.py
@@ -53,7 +53,7 @@ class Database:
         """
         Function will insert variable with name and value in variables collection in MongoDB.
         :param name: string for variable name
-        :param value: value which can be of many types.
+        :param value: value which can be of many types. The type control should not be done in this function.
         :return: None
         """
         self.__variables.update_one({}, {"$set": {name: value}})

--- a/error_handling.py
+++ b/error_handling.py
@@ -25,7 +25,9 @@ async def send_error_message_to_user(ctx: discord.ApplicationContext, error: dis
                           "moderátorů.", ephemeral=True)
         guild = ctx.guild
         channel = discord.utils.get(guild.channels, name=CHANNEL_NAME)
+        if channel is None:
+            raise Exception()
         await channel.send(error_message)
-    except AttributeError:
+    except Exception:
         print(f"Channel {CHANNEL_NAME} neexistuje, printuji do konzole\n")
         print(error_message)

--- a/error_handling.py
+++ b/error_handling.py
@@ -1,11 +1,10 @@
 """This file will be responsible for sending error messages whenever a command unexpectedly fails"""
 import discord
+from discord.ext import commands
 
 CHANNEL_NAME = "bot-development"
 
 
-# TODO: Test if the function is triggered by errors such as no permission or no
-# It is not. Fix?
 async def send_error_message_to_user(ctx: discord.ApplicationContext, error: discord.DiscordException) -> None:
     """
     Sends back to user a warning when slash command fails and info in bot-development channel
@@ -13,6 +12,11 @@ async def send_error_message_to_user(ctx: discord.ApplicationContext, error: dis
     :param error: raised exception from slash command
     :return: None
     """
+
+    if isinstance(error, commands.MissingPermissions):
+        await ctx.respond("Nemáš na toto práva.", ephemeral=True)
+        return
+
     error_message = (f"Uživatel {ctx.user.mention} použil příkaz **->{ctx.command.qualified_name}<-** "
                      f"který selhal.\nChyba: **{repr(error)}**")
 

--- a/start.py
+++ b/start.py
@@ -22,9 +22,10 @@ cog_list = [
     "leaderboard",
     "login_info",
     "welcome_message",
-    "countdown",
+    # "countdown", - This module is for now removed as it is not useful
     "semester_switching",
     "database_communication",
+    "help",
 ]
 
 # load every cog in cog_list

--- a/start.py
+++ b/start.py
@@ -23,6 +23,7 @@ cog_list = [
     "login_info",
     "welcome_message",
     "countdown",
+    "semester_switching",
 ]
 
 # load every cog in cog_list

--- a/start.py
+++ b/start.py
@@ -24,6 +24,7 @@ cog_list = [
     "welcome_message",
     "countdown",
     "semester_switching",
+    "database_communication",
 ]
 
 # load every cog in cog_list


### PR DESCRIPTION
I have completed all tasks from automated semester switching.

 (optional) Accept a "list" of channels, their descriptions and category names to create these channels.
 (optional) Add the next study year role to members missing them (i.e. add role "Druhák" to members having only "Prvák" when switching to next year) -- it seems like a good idea on paper but we might wanna ask others about this
 
 These two I will not make as:
 1. Does that seem more work than doing it by hand?
 2. that would be too many API calls (hundreds of people) and probably not wanted. We discussed with @Astra3 that this is not wanted. One announcement ping to tell people to change it is enough.
 
 Anyway, all the main features should be done. I ask you to test it thoroughly and you can mention all the bugs and your opinions here. Ask me here or on Discord if you do not understand something I have implemented.