### PR TITLE
Autovoice channel bugfix

### DIFF
--- a/bot/auto_voice.py
+++ b/bot/auto_voice.py
@@ -25,7 +25,12 @@ async def create_new_channel(user: discord.Member, category: discord.CategoryCha
     created_channel = await discord_server.create_voice_channel(name=new_channel_name, category=category)
 
     # move the user to the newly created channel
-    await user.move_to(created_channel)
+    try:
+        await user.move_to(created_channel)
+    except Exception:
+        await created_channel.delete(reason="Uzivatel si to rozmyslel")
+        return
+
 
     # return the created channel
     return created_channel.id

--- a/bot/auto_voice.py
+++ b/bot/auto_voice.py
@@ -31,7 +31,6 @@ async def create_new_channel(user: discord.Member, category: discord.CategoryCha
         await created_channel.delete(reason="Uzivatel si to rozmyslel")
         return
 
-
     # return the created channel
     return created_channel.id
 
@@ -66,10 +65,10 @@ class AutoVoice(commands.Cog):
 
     @commands.Cog.listener()
     async def on_voice_state_update(
-        self,
-        member: discord.Member,
-        before: discord.VoiceState,
-        after: discord.VoiceState,
+            self,
+            member: discord.Member,
+            before: discord.VoiceState,
+            after: discord.VoiceState,
     ) -> None:
         """This function checks if a channel can be deleted after someone leaves.
         :param member: Member, who left
@@ -113,14 +112,14 @@ class AutoVoice(commands.Cog):
     @commands.slash_command(name="set-auto-voice-channel")
     @commands.has_permissions(administrator=True)
     async def set_auto_voice(
-        self,
-        ctx: discord.ApplicationContext,
-        auto_channel_id: str,
-        storage: discord.Option(
-            str,
-            description="Uložit lokálně do proměnné či DB (Databáze preferováno)",
-            choices=["local", "db"],
-        ),
+            self,
+            ctx: discord.ApplicationContext,
+            auto_channel_id: str,
+            storage: discord.Option(
+                str,
+                description="Uložit lokálně do proměnné či DB (Databáze preferováno)",
+                choices=["local", "db"],
+            ),
     ) -> None:
         """Set the automatic voice primary ID to the one specified by the user.
         :param ctx: Context of slash command
@@ -128,10 +127,10 @@ class AutoVoice(commands.Cog):
         :param storage: Local variable or database
         :return: None
         """
-        
+
         try:
             auto_channel_id: int = int(auto_channel_id)
-        except:
+        except ValueError:
             ctx.respond("Neplatna hodnota channel id!", ephemeral=True)
             return
 

--- a/bot/auto_voice.py
+++ b/bot/auto_voice.py
@@ -103,7 +103,6 @@ class AutoVoice(commands.Cog):
 
         # check if a channel the member left can be deleted
         # and if the channel doesn't have any members connected, delete it
-        print(f"{can_be_deleted}, {before.channel}, {after.channel}")
         if can_be_deleted and len(before.channel.members) == 0:
             await before.channel.delete()
 


### PR DESCRIPTION
Should fix the case where the user leaves the channel creating voice channel before he was moved to his channel. Previously this would leave the newly created channel vacant. Now it should in the majority of cases be deleted.