### PR TITLE
Semester switching now supports master's degrees channel (N1. semestr)

### DIFF
--- a/bot/database_communication.py
+++ b/bot/database_communication.py
@@ -76,7 +76,7 @@ class DatabaseCommunication(commands.Cog):
                 "Proměnná s tímto názvem nebyla nalezena. "
                 "Použijte příkaz /print-names-from-db pro veškeré názvy proměnných aktuálně v DB.", ephemeral=True)
         else:
-            await ctx.respond(f"Proměnná se jménem {name} má hodnotu |{value}|.", ephemeral=True)
+            await ctx.respond(f"Proměnná se jménem {name} má hodnotu >{value}< s typem {type(value)}.", ephemeral=True)
 
     @commands.slash_command(name="print-names-from-db",
                             description="Tento příkaz ti vypíše všechny názvy proměnných v DB.")


### PR DESCRIPTION
This is kinda an important change, the logic itself remained, but I have changed the way the year of the category is calculated and handled. This should be easier to expand in the future by adding an "if" and expanding the regex, and that's it.

Please test:

Channels are sorted correctly in order:

```
random text categories
N1. semestr
5. semestr
3. semestr
1. semestr
voice category
N2. semestr - archiv
6. semestr - archiv
4. semestr - archiv
2. semestr - archiv
random text categories

```
Of course, the order will depend on which channels you will switch to or which years you will create, but the structure must be like this.


Permissions are correct:

Active channels must have roles according to the corresponding year (1. and 2. semester 1. year, 3. and 4. semestr 2. year, etc.)
Archived channels must not have roles!


